### PR TITLE
image_library_patch4

### DIFF
--- a/project/lib/image_library.py
+++ b/project/lib/image_library.py
@@ -5,16 +5,11 @@ import cv2
 import numpy as np
 from scipy.misc import imread
 import glob
-#patch2 options : add colour value instead of 0s as additional vectors
-#               : repeat vectors to fill additional spots
-#               : use colour value or number of vectors as a multiplier
+
 #list of images features for all images in data/small_album_images
 def create_image_feature_array():
     images = glob.glob('data/small_album_images/*.jpg')
-    num_images = len(images)
-    feature_array = [None for i in range(num_images)]
-    for im in range(num_images):
-        feature_array[im] = get_image_features(images[im])
+    feature_array = [get_image_features(img) for img in images]
     return feature_array
 
 # Turn an image file into an array of features, returns 0s if fails
@@ -24,8 +19,6 @@ def get_image_features(image_path):
         return features
     else:
         features = resize_array(features)
-        if(check_size(features)):
-            print("successfully changes")
         return features
 
 #ensures array is size 200*64
@@ -42,7 +35,7 @@ def resize_array(array):
         array = np.concatenate([array, zero_vector])
     return array
 
-#returns 1 if array is correct size, else 0
+#returns True if array is correct size, else False
 def check_size(array):
     correct_size = True
     if(len(array) != 200):
@@ -72,5 +65,3 @@ def extract_features(image_path, vector_size=200):
         print ('Error: ', e)
         return [np.zeros(64) for i in range(200)]
     return dsc
-
-create_image_feature_array()

--- a/project/lib/image_library.py
+++ b/project/lib/image_library.py
@@ -1,8 +1,76 @@
 """
 A library for all functions image-related
 """
+import cv2
+import numpy as np
+from scipy.misc import imread
+import glob
+#patch2 options : add colour value instead of 0s as additional vectors
+#               : repeat vectors to fill additional spots
+#               : use colour value or number of vectors as a multiplier
+#list of images features for all images in data/small_album_images
+def create_image_feature_array():
+    images = glob.glob('data/small_album_images/*.jpg')
+    num_images = len(images)
+    feature_array = [None for i in range(num_images)]
+    for im in range(num_images):
+        feature_array[im] = get_image_features(images[im])
+    return feature_array
 
-
-# Turn an image file into an array of features
+# Turn an image file into an array of features, returns 0s if fails
 def get_image_features(image_path):
-    pass
+    features = extract_features(image_path)
+    if(check_size(features)):
+        return features
+    else:
+        features = resize_array(features)
+        if(check_size(features)):
+            print("successfully changes")
+        return features
+
+#ensures array is size 200*64
+def resize_array(array):
+    num_vectors = len(array)
+    for v in range(num_vectors):
+    #ensure all vectors are length 64
+        v_size = len(array[v])
+        if(v_size < 64):
+            array[v] = np.concatenate([array[v], np.zeros(64 - v_size)])
+    #ensures 200 vectors
+    if(num_vectors < 200):
+        zero_vector = [np.zeros(64) for i in range(200-num_vectors)]
+        array = np.concatenate([array, zero_vector])
+    return array
+
+#returns 1 if array is correct size, else 0
+def check_size(array):
+    correct_size = True
+    if(len(array) != 200):
+        correct_size = False
+    for v in range(len(array)):
+        if(len(array[v]) != 64):
+            correct_size = False
+    return correct_size
+
+#returns feature list of size 200*64
+def extract_features(image_path, vector_size=200):
+    image = imread(image_path, mode="RGB")
+    try:
+        alg = cv2.KAZE_create()
+        # Finding image keypoints
+        kps = alg.detect(image)
+        # Getting first 200 of them. 
+        # Number of keypoints is varies depend on image size and color pallet
+        # Sorting them based on keypoint response value(bigger is better)
+        kps = sorted(kps, key=lambda x: -x.response)[:vector_size]
+        # computing descriptors vector
+        if(len(kps) > 0):
+            kps, dsc = alg.compute(image, kps)
+        else:
+            dsc = [[0]*64 for i in range(200)]
+    except cv2.error as e:
+        print ('Error: ', e)
+        return [np.zeros(64) for i in range(200)]
+    return dsc
+
+create_image_feature_array()


### PR DESCRIPTION
corrected error from previous patches

# Proposed Change
- removed error from plain images (no keypoints)
### High-level summary
plain images (ex. ACDCs Back in Black album) have no keypoints. This returns a feature array of NoneType. This was fixed by returning a 2D list of zeros when no keypoints are present
### List of specific changes

- if statement in extract_features() checks if any keypoints are detected
- keypoints detected, run as before
- keypoints not detected, create a list of zeros

### Checklist

- [x] I have tested my changes locally
- [x] I have added comments to my code where necessary
- [x] I have listed any resources that were used in the process

### Questions / comments for reviewers
