### PR TITLE
Rethink weights strategy

### DIFF
--- a/project/train.py
+++ b/project/train.py
@@ -18,15 +18,11 @@ image_features = create_image_feature_array()
 print("Training the network")
 model = create_network()
 
-filepath = "weights/improvement-{epoch:02d}-{loss:.4f}-bigger.hdf5"
-checkpoint = ModelCheckpoint(filepath,
+checkpoint = ModelCheckpoint("weights.hdf5",
                              monitor='loss',
                              verbose=0,
                              save_best_only=True,
                              mode='min')
 
-if not path.isdir("weights"):
-    mkdir("weights")
-
 model.fit(image_features, song_features, batch_size=100,
-          epochs=400000, callbacks=[checkpoint])
+          epochs=4000, callbacks=[checkpoint])


### PR DESCRIPTION
# Proposed Change
Change the way we handle weights to be more scaleable

### High-level summary
Currently a new HDF5 weights file is made for every epoch with the best loss so far, however this is going to lead to issues considering the number of epochs we are running. So in this PR is a better approach where we save the single best file.

### List of specific changes
- Update `train.py` to handle weights better
- Change epochs from 400000 to 4000

### Checklist

- [x] I have tested my changes locally
- [x] I have added comments to my code where necessary
- [x] I have listed any resources that were used in the process

### Questions / comments for reviewers
No